### PR TITLE
chore(config): Removes category filter from post queries ... etc

### DIFF
--- a/_app/sanity.types.ts
+++ b/_app/sanity.types.ts
@@ -166,6 +166,7 @@ export type Post = {
     _type: 'block';
     _key: string;
   }>;
+  category: 'upcoming' | 'completed' | 'hidden';
 };
 
 export type SanityImagePaletteSwatch = {
@@ -342,7 +343,7 @@ export type FaqQueryResult = {
   }> | null;
 } | null;
 // Variable: allPostsQuery
-// Query: *[_type == "post" && defined(slug.current) && category == "upcoming"] |  order(date desc, _createdAt desc) {      _id,  _updatedAt,  "title": coalesce(title, "Untitled Estate Sale"),  "slug": slug.current,  coverImage,  eventDates,  location {    fullAddress,    coordinates {      lat,      lng    }  }  }
+// Query: *[_type == "post" && defined(slug.current)] |  order(date desc, _createdAt desc) {      _id,  _updatedAt,  "title": coalesce(title, "Untitled Estate Sale"),  "slug": slug.current,  coverImage,  eventDates,  location {    fullAddress,    coordinates {      lat,      lng    }  }  }
 export type AllPostsQueryResult = Array<{
   _id: string;
   _updatedAt: string;
@@ -370,7 +371,7 @@ export type AllPostsQueryResult = Array<{
   };
 }>;
 // Variable: slicedPostsQuery
-// Query: *[  _type == "post" && defined(slug.current) && category == "upcoming"]|order(_createdAt desc)[0...12]{_id, title, slug, coverImage, location, eventDates}
+// Query: *[  _type == "post" && defined(slug.current)]|order(_createdAt desc)[0...12]{_id, title, slug, coverImage, location, eventDates}
 export type SlicedPostsQueryResult = Array<{
   _id: string;
   title: string;
@@ -535,7 +536,7 @@ export type PostQueryResult = {
   };
 } | null;
 // Variable: markerPostsQuery
-// Query: *[    _type == "post" &&    defined(slug.current) &&    category == "upcoming" &&    defined(location.coordinates.lat) &&    defined(location.coordinates.lng)  ]{    _id,    "title": coalesce(title, "Untitled Estate Sale"),    "slug": slug.current,    location {      fullAddress,      coordinates {        lat,        lng      }    }  }
+// Query: *[    _type == "post" &&    defined(slug.current) &&    defined(location.coordinates.lat) &&    defined(location.coordinates.lng)  ]{    _id,    "title": coalesce(title, "Untitled Estate Sale"),    "slug": slug.current,    location {      fullAddress,      coordinates {        lat,        lng      }    }  }
 export type MarkerPostsQueryResult = Array<{
   _id: string;
   title: string;
@@ -569,11 +570,11 @@ declare module '@sanity/client' {
     '*[_type == "contactInfo"][0]': ContactInfoQueryResult;
     '*[_type == "reviews"][0]{\n  items[]{\n    rating,\n    review,\n    name\n  }\n}': TestimonialQueryResult;
     '*[_type == "faqs"][0]{\n  items[] {\n    question,\n    answer\n  }\n}': FaqQueryResult;
-    '\n  *[_type == "post" && defined(slug.current) && category == "upcoming"] |\n  order(date desc, _createdAt desc) {\n    \n  _id,\n  _updatedAt,\n  "title": coalesce(title, "Untitled Estate Sale"),\n  "slug": slug.current,\n  coverImage,\n  eventDates,\n  location {\n    fullAddress,\n    coordinates {\n      lat,\n      lng\n    }\n  }\n\n  }\n': AllPostsQueryResult;
-    '*[\n  _type == "post" && defined(slug.current) && category == "upcoming"\n]|order(_createdAt desc)[0...12]{_id, title, slug, coverImage, location, eventDates}': SlicedPostsQueryResult;
+    '\n  *[_type == "post" && defined(slug.current)] |\n  order(date desc, _createdAt desc) {\n    \n  _id,\n  _updatedAt,\n  "title": coalesce(title, "Untitled Estate Sale"),\n  "slug": slug.current,\n  coverImage,\n  eventDates,\n  location {\n    fullAddress,\n    coordinates {\n      lat,\n      lng\n    }\n  }\n\n  }\n': AllPostsQueryResult;
+    '*[\n  _type == "post" && defined(slug.current)\n]|order(_createdAt desc)[0...12]{_id, title, slug, coverImage, location, eventDates}': SlicedPostsQueryResult;
     '\n  *[_type == "post" && _id != $skip && defined(slug.current)]\n    | order(date desc, _updatedAt desc) [0...$limit] {\n    \n  _id,\n  _updatedAt,\n  "title": coalesce(title, "Untitled Estate Sale"),\n  "slug": slug.current,\n  coverImage,\n  eventDates,\n  location {\n    fullAddress,\n    coordinates {\n      lat,\n      lng\n    }\n  }\n\n  }\n': MorePostsQueryResult;
     '\n  *[_type == "post" && slug.current == $slug] [0] {\n    body[]{...},\n    gallery[]{...},\n    \n  _id,\n  _updatedAt,\n  "title": coalesce(title, "Untitled Estate Sale"),\n  "slug": slug.current,\n  coverImage,\n  eventDates,\n  location {\n    fullAddress,\n    coordinates {\n      lat,\n      lng\n    }\n  }\n\n  }\n': PostQueryResult;
-    '\n  *[\n    _type == "post" &&\n    defined(slug.current) &&\n    category == "upcoming" &&\n    defined(location.coordinates.lat) &&\n    defined(location.coordinates.lng)\n  ]{\n    _id,\n    "title": coalesce(title, "Untitled Estate Sale"),\n    "slug": slug.current,\n    location {\n      fullAddress,\n      coordinates {\n        lat,\n        lng\n      }\n    }\n  }\n': MarkerPostsQueryResult;
+    '\n  *[\n    _type == "post" &&\n    defined(slug.current) &&\n    defined(location.coordinates.lat) &&\n    defined(location.coordinates.lng)\n  ]{\n    _id,\n    "title": coalesce(title, "Untitled Estate Sale"),\n    "slug": slug.current,\n    location {\n      fullAddress,\n      coordinates {\n        lat,\n        lng\n      }\n    }\n  }\n': MarkerPostsQueryResult;
     '\n  *[_type == "post" && defined(slug.current)]\n  {"slug": slug.current}\n': PostPagesSlugsResult;
     '\n  *[_type == "post" && defined(slug.current)] | order(_type asc) {\n    "slug": slug.current,\n    _type,\n    _updatedAt,\n  }\n': SitemapDataResult;
   }

--- a/_app/src/app/_components/header.tsx
+++ b/_app/src/app/_components/header.tsx
@@ -48,6 +48,7 @@ export default function Header() {
                 alt='Logo'
                 width={272}
                 height={90}
+                priority
               />
             </div>
           </Link>

--- a/_app/src/app/_utils/createMapLink.ts
+++ b/_app/src/app/_utils/createMapLink.ts
@@ -1,5 +1,5 @@
 export function createMapLink(address: string) {
-  if (!address) return '';
+  if (!address) return;
   const encodedAddress = encodeURIComponent(address);
   const appleMapsUrl = `https://maps.apple.com/?q=${encodedAddress}`;
   const googleMapsUrl = `https://www.google.com/maps/search/?api=1&query=${encodedAddress}`;

--- a/_app/src/sanity/lib/api.ts
+++ b/_app/src/sanity/lib/api.ts
@@ -21,14 +21,4 @@ export const projectId = assertValue(
   'Missing environment variable: NEXT_PUBLIC_SANITY_PROJECT_ID',
 );
 
-/**
- * see https://www.sanity.io/docs/api-versioning for how versioning works
- */
-export const apiVersion =
-  process.env.NEXT_PUBLIC_SANITY_API_VERSION || '2024-10-28';
-
-/**
- * Used to configure edit intent links, for Presentation Mode, as well as to configure where the Studio is mounted in the router.
- */
-export const studioUrl =
-  process.env.NEXT_PUBLIC_SANITY_STUDIO_URL || 'http://localhost:3333';
+export const apiVersion = process.env.NEXT_PUBLIC_SANITY_API_VERSION;

--- a/_app/src/sanity/lib/client.ts
+++ b/_app/src/sanity/lib/client.ts
@@ -1,5 +1,5 @@
 import { createClient } from 'next-sanity';
-import { apiVersion, dataset, projectId, studioUrl } from './api';
+import { apiVersion, dataset, projectId } from './api';
 
 export const client = createClient({
   projectId,
@@ -7,16 +7,4 @@ export const client = createClient({
   apiVersion,
   useCdn: false,
   perspective: 'published',
-  stega: {
-    studioUrl,
-    // Set logger to 'console' for more verbose logging
-    // logger: console,
-    filter: (props) => {
-      if (props.sourcePath.at(-1) === 'title') {
-        return true;
-      }
-
-      return props.filterDefault(props);
-    },
-  },
 });

--- a/_app/src/sanity/lib/utils.ts
+++ b/_app/src/sanity/lib/utils.ts
@@ -1,10 +1,9 @@
 import createImageUrlBuilder from '@sanity/image-url';
-import { dataset, projectId, studioUrl } from '@/sanity/lib/api';
-import { createDataAttribute, CreateDataAttributeProps } from 'next-sanity';
+import { dataset, projectId } from '@/sanity/lib/api';
 
 const imageBuilder = createImageUrlBuilder({
-  projectId: projectId || '',
-  dataset: dataset || '',
+  projectId: projectId,
+  dataset: dataset,
 });
 
 export const urlForImage = (source: { asset?: { _ref?: string } }) => {
@@ -25,15 +24,4 @@ export function resolveOpenGraphImage(
   const url = urlForImage(image)?.width(1200).height(627).fit('crop').url();
   if (!url) return;
   return { url, alt: image?.alt as string, width, height };
-}
-
-type DataAttributeConfig = CreateDataAttributeProps &
-  Required<Pick<CreateDataAttributeProps, 'id' | 'type' | 'path'>>;
-
-export function dataAttr(config: DataAttributeConfig) {
-  return createDataAttribute({
-    projectId,
-    dataset,
-    baseUrl: studioUrl,
-  }).combine(config);
 }

--- a/studio/environment.ts
+++ b/studio/environment.ts
@@ -1,1 +1,3 @@
 export const googleMapsApiKey = process.env.SANITY_STUDIO_GOOGLE_MAPS_API_KEY;
+export const projectId = process.env.SANITY_STUDIO_PROJECT_ID;
+export const dataset = process.env.SANITY_STUDIO_DATASET;

--- a/studio/sanity.cli.ts
+++ b/studio/sanity.cli.ts
@@ -6,11 +6,7 @@
  */
 
 import { defineCliConfig } from 'sanity/cli';
-
-// const projectId =  'ma2ex8bh';
-// const projectId = 'lc0v2d89';
-const projectId = process.env.SANITY_STUDIO_PROJECT_ID || 'ma2ex8bh';
-const dataset = process.env.SANITY_STUDIO_DATASET || 'production';
+import { dataset, projectId } from './environment';
 
 export default defineCliConfig({
   api: {

--- a/studio/sanity.config.ts
+++ b/studio/sanity.config.ts
@@ -6,10 +6,11 @@ import { deskStructure } from './structure';
 import { googleMapsInput } from '@sanity/google-maps-input';
 import { googleMapsApiKey } from './environment';
 
-// Environment variables for project configuration
-// senet-estate-sales_web
-// const projectId = 'lc0v2d89';
-// const projectId = process.env.SANITY_STUDIO_PROJECT_ID || 'lc0v2d89';
+if (!googleMapsApiKey) {
+  throw new Error(
+    'Missing environment variable: SANITY_STUDIO_GOOGLE_MAPS_API_KEY',
+  );
+}
 
 // Senet estate sales LLC:
 const projectId = process.env.SANITY_STUDIO_PROJECT_ID || 'ma2ex8bh';
@@ -25,13 +26,13 @@ export default defineConfig({
         structureTool({ structure: deskStructure }),
         visionTool(),
         googleMapsInput({
-          apiKey: 'AIzaSyBPqt_txCmQfNnQDRWUeEyZOdCRfejuXlc',
+          apiKey: googleMapsApiKey,
         }),
       ]
     : [
         structureTool({ structure: deskStructure }),
         googleMapsInput({
-          apiKey: 'AIzaSyBPqt_txCmQfNnQDRWUeEyZOdCRfejuXlc',
+          apiKey: googleMapsApiKey,
         }),
       ],
   schema: {


### PR DESCRIPTION
Removes the `category` filter from Sanity queries for posts. This ensures that all posts, regardless of their category status, are included in the query results.

The category filter was previously applied to the following queries:
- AllPostsQueryResult
- SlicedPostsQueryResult
- MarkerPostsQueryResult

The `category` field is also added to the Post type definition.

Adds `priority` attribute to the header logo for improved loading performance.

Also, `googleMapsApiKey` added in sanity config to make sure it exists before proceeding.

Fixes potential issue with map link generation where an empty address would cause errors.